### PR TITLE
Try to fix NumericField.VALIDATION

### DIFF
--- a/mysite/code/Page.php
+++ b/mysite/code/Page.php
@@ -9,11 +9,14 @@ class Page extends SiteTree {
 		'FadeSeconds' => 'Decimal',
 		'UseColorbox' => 'Boolean'
 	);
+    
+    require_once THIRDPARTY_PATH."/Zend/Locale/Format.php";
+
 	static $defaults = array(
-		'ShufflerWidth' => 400,
-		'ShufflerHeight' => 300,
-		'PauseSeconds' => 5.0,
-		'FadeSeconds' => 0.70
+        'ShufflerWidth' => 400,
+        'ShufflerHeight' => 300,
+        'PauseSeconds' => Zend_Locale_Format::toNumber(5, array('precision' => 2,'locale' => i18n::get_locale()))
+        'FadeSeconds' => Zend_Locale_Format::toNumber(0.7,array('precision' => 2,'locale' => i18n::get_locale()))
 	);
 	static $has_many = array (
 		'Images' => 'ImageResource'


### PR DESCRIPTION
![schermafbeelding 2014-06-27 om 10 14 59](https://cloud.githubusercontent.com/assets/3128596/3409533/0f5fd738-fdda-11e3-9999-62f723781b00.png)
Not sure this is the correct fix for issue #13, but it looks like the validator check the numericfield for localized input (https://github.com/silverstripe/silverstripe-framework/blob/ff1b0e3a0882075d639147c1ee040ae206432390/forms/NumericField.php). Let us set a localized input by default too.
